### PR TITLE
Update docker tag of ledr sensor to current version 1.6.0-21823

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,11 +22,11 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/linux-edr-sensor/CHANGELOG.md
+++ b/charts/linux-edr-sensor/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2023-11-13
+
+### Changed
+- Updated `appVersion` to the `1.6.0-21823` docker tag for the sensor image
+
 ## [0.1.2] - 2023-09-06
 
 ### Changed

--- a/charts/linux-edr-sensor/CHANGELOG.md
+++ b/charts/linux-edr-sensor/CHANGELOG.md
@@ -8,6 +8,7 @@ The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ### Changed
 - Updated `appVersion` to the `1.6.0-21823` docker tag for the sensor image
+- Updated the chart-testing action to `2.6.1`
 
 ## [0.1.2] - 2023-09-06
 

--- a/charts/linux-edr-sensor/Chart.yaml
+++ b/charts/linux-edr-sensor/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the sensor being deployed by the chart.
-appVersion: "1.5.4-21043"
+appVersion: "1.6.0-21823"
 
 keywords:
   - redcanary


### PR DESCRIPTION
# Description

- Updates the appVersion of the chart to use use the 1.6.0-21823 docker tag which is the current latest sensor version
- Updates the chart-testing action as there was a fix for an [issue](https://github.com/helm/chart-testing-action/issues/132) applied in 2.5.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unable to run chart testing on my local Rancher K3s cluster atm but it did pass in CI. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
