### PR TITLE
OpenShift support for linux-edr-sensor chart

### DIFF
--- a/charts/linux-edr-sensor/CHANGELOG.md
+++ b/charts/linux-edr-sensor/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2025-01-09
+
+### Changed
+- Added support for installing in OpenShift/OKd clusters.
+
 ## [0.1.9] - 2024-11-05
 
 ### Changed

--- a/charts/linux-edr-sensor/Chart.yaml
+++ b/charts/linux-edr-sensor/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the sensor being deployed by the chart.
 appVersion: "1.10.2-25540"

--- a/charts/linux-edr-sensor/README.md.gotmpl
+++ b/charts/linux-edr-sensor/README.md.gotmpl
@@ -57,12 +57,13 @@ kubectl label --overwrite ns <NAMESPACE_NAME> pod-security.kubernetes.io/enforce
 ### Create a secret to hold your private registry credentials
 The image pull secret is used to securely authenticate and authorize container image pulls from your private container registry. *This may not be required in all environments*
 
+For the `docker-server` parameter, use the base URL for the registry server. For example, if it is hosted at `docker.mydomain.com` use `--docker-server="https://docker.mydomain.com"`
+
 ```console
 kubectl create secret docker-registry <SECRET_NAME> \
-  --docker-server=<YOUR_REGISTRY_SERVER> \
+  --docker-server=<YOUR_REGISTRY_SERVER_URL> \
   --docker-username=<YOUR_USERNAME> \
   --docker-password=<YOUR_PASSWORD> \
-  --docker-email=<YOUR_EMAIL> \
   --namespace=<NAMESPACE_FROM_ABOVE>
   ```
 
@@ -79,13 +80,17 @@ helm search repo redcanary/linux-edr-sensor --versions
 ```
 
 ### Install the Helm chart
+For the `image.repository` parameter, you need to specify the container image as you would to docker. For example, if your registry is at `docker.mydomain.com` and you kept the image name as `canary_forwarder`, you would use `--set image.repository="docker.mydomain.com/canary_forwarder"`.
+
+It is a best practice to use specific image tags rather than floating tags like `latest`, so be sure to specify the specific latest version in the `image.tag` parameter. For example, `--set image.tag=1.10.2-25540`.
+
 ```console
 helm install linux-edr-sensor redcanary/linux-edr-sensor \
 --version <VERSION_FROM_ABOVE> \
 --namespace=<NAMESPACE_FROM_ABOVE> \
 --set config.accessToken=<YOUR_ACCESS_TOKEN> \
 --set config.outpostAuthToken=<YOUR_OUTPOST_TOKEN> \
---set image.repository=<YOUR_REGISTRY_SERVER> \
+--set image.repository=<YOUR_REPOSITORY_NAME>/<IMAGE_NAME> \
 --set image.tag=<DESIRED TAG> \
 --set imagePullSecrets[0].name=<SECRET_NAME_FROM_ABOVE>  # Omit if not using an image pull secret
 ```
@@ -120,6 +125,49 @@ Uninstalling the helm chart will not remove the namespace or image pull secret. 
 kubectl delete ns <YOUR_NAMESPACE>
 ```
 
+## OpenShift Install
+
+Installing on OpenShift requires some additional steps before the instructions listed above, as well as some small modifications to them.
+
+1. Create and configure the project and a service account for it
+    ```console
+    oc new-project linux-edr-sensor
+    ```
+
+    ```console
+    oc create sa linux-edr-sensor
+    ```
+
+    OpenShift project creation also creates a namespace of the same name, so keep that in mind for `helm` and `kubectl` commands that take namespace arguments.
+
+
+2. Configure policy for the new service account
+    ```console
+    oc adm policy add-scc-to-user privileged -z linux-edr-sensor
+    ```
+
+    This adds the `privileged` Security Context Contstraint to the service account's constraints. This allows pods that specify this service acount to run effectively without security constraints. This is necessary because the sensor needs full access to all of the host resources to properly monitor all the other activity on the node.
+
+3. Follow normal install instructions with some minor changes
+    Skip the first step of namespace creation, since one was already created with the project.
+
+    Follow the rest of the steps until the final one, using `linux-edr-sensor` as the namespace name.
+
+    For the final `helm install` command, you will need to add two extra `--set` flags to ensure the chart installs the pods with the correct service account association:
+
+    ```console
+    --set useServiceAccount=true \
+    --set serviceAccountName=linux-edr-sensor \
+    ```
+
+    OpenShift clusters (aside from single-node development clusters) also have control plane nodes tainted by default, so a toleration will need to be added to allow monitoring control plane nodes:
+
+    ```console
+    --set tolerations[0].key="node-role.kubernetes.io/master"
+    --set tolerations[0].effect=NoSchedule
+    ```
+
+    You may want to use the `--dry-run` parameter to `helm` on your first attempt in order to look at the resulting resources, to make sure the `serviceAccountName` and `tolerations` are set as you expected in the pod spec.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/linux-edr-sensor/templates/daemonset.yaml
+++ b/charts/linux-edr-sensor/templates/daemonset.yaml
@@ -22,6 +22,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.useServiceAccount }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       hostNetwork: true
       hostPID: true
       {{- with .Values.tolerations }}

--- a/charts/linux-edr-sensor/values.yaml
+++ b/charts/linux-edr-sensor/values.yaml
@@ -61,6 +61,12 @@ affinity: {}
   #             values:
   #               - amd64
 
+# -- Whether or not the DaemonSet's pod should be associated with a ServiceAccount
+useServiceAccount: false
+
+# -- If a ServiceAccount is being used, this names it
+serviceAccountName: ""
+
 persistence:
   # -- Whether or not persistent storage should be used for the sensor's /tmp and /logs data.
   enabled: true


### PR DESCRIPTION
# Description

Adds support for installing the `linux-edr-sensor` chart in OpenShift clusters.

This is largely documentation in the chart's README, but it includes in the chart itself optional changes to the DaemonSet's PodSpec to associate it with a ServiceAccount. The installation instructions describe how to use this ServiceAccount to associate the sensor pods with the "Privileged" SCC, which is necessary to allow them to be scheduled with OpenShift's extra security checks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

The instructions and updated chart have been tested against a single-node OpenShift cluster, where it could be installed and upgraded successfully. The instructions regarding how to allow the sensor to run on control plane nodes were tested in a separate non-OpenShift multi-node cluster with a separate control plane node, as I don't currently have access to an OpenShift cluster with a separate control plane.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
