### PR TITLE
[LE-1293] linux-edr-sensor: Allow override of nodestate mount for GKE support

### DIFF
--- a/charts/linux-edr-sensor/CHANGELOG.md
+++ b/charts/linux-edr-sensor/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2025-02-05
+
+### Changed
+- GKE and OpenShift are now listed as supported distributions in README.md
+- The `persistence` value now also controls the `nodestate` mount for the container and allows setting it via `persistence.nodestateDir`. This is necessary for proper GKE support.
+- The README.md file now describes the required `persistence.nodestateDir` setting for GKE installs.
+
 ## [0.1.10] - 2025-01-09
 
 ### Changed

--- a/charts/linux-edr-sensor/Chart.yaml
+++ b/charts/linux-edr-sensor/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the sensor being deployed by the chart.
 appVersion: "1.10.2-25540"

--- a/charts/linux-edr-sensor/README.md
+++ b/charts/linux-edr-sensor/README.md
@@ -12,6 +12,8 @@ The linux-edr-sensor chart has undergone testing for deployment on these Kuberne
 * Rancher k3s & k3d
 * Amazon EKS
 * Azure AKS
+* Google GKE (see extra configuration requirements below)
+* OpenShift (see special instructions below)
 
 ## Multi-architecture kubernetes clusters
 The current state of the Canary Forwarder Docker image does not support multi-architecture builds. In the context of a multi-architecture Kubernetes cluster (including both arm64 and amd64 nodes), deploying two daemonsets becomes necessary. Each daemonset should reference the respective image and incorporate the required affinities to accommodate this architecture diversity.
@@ -125,6 +127,16 @@ Uninstalling the helm chart will not remove the namespace or image pull secret. 
 kubectl delete ns <YOUR_NAMESPACE>
 ```
 
+## Google Kubernetes Engine Configuration
+
+When installing the sensor in a Google Cloud environment using Google's Container Optimized OS, you must ensure that the persistent directory for node state is placed in a different location than default, because the default location is mounted with the `noexec` flag.
+
+An option to `helm install` that has been tested to work is the following:
+
+```console
+--set persistence.nodestateDir=/var/lib/toolbox/redcanary
+```
+
 ## OpenShift Install
 
 Installing on OpenShift requires some additional steps before the instructions listed above, as well as some small modifications to them.
@@ -187,9 +199,10 @@ Installing on OpenShift requires some additional steps before the instructions l
 | labels | object | `{}` | Additional labels to add to all the resources created by this chart. |
 | nameOverride | string | `""` | String to partially override linux-edr-sensor.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` | When you specify a nodeSelector, the Kubernetes scheduler will only consider nodes that match the labels you have specified. nodeAffinity is preferred see k8s documentations for further detail - https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ |
-| persistence.enabled | bool | `true` | Whether or not persistent storage should be used for the sensor's /tmp and /logs data. |
-| persistence.logDir | string | `"/var/log"` | The path on the host to use for persistent log storage. Only used when type is set to 'hostpath'. |
-| persistence.tmpDir | string | `"/tmp"` | The path on the host to use for persistent tmp storage. Only used when type is set to 'hostpath'. |
+| persistence.enabled | bool | `true` | Whether or not persistent storage should be used for the sensor's /var, /tmp and /logs data. |
+| persistence.logDir | string | `"/var/log"` | The path on the host to use for persistent log storage. Only used when enabled is set to true. |
+| persistence.nodestateDir | string | `"/var/lib/misc/redcanary"` | The path on the host to use for persistent node state. You must ensure this is not on a mount with the 'noexec' flag. Only used when enabled is set to true. |
+| persistence.tmpDir | string | `"/tmp"` | The path on the host to use for persistent tmp storage. Only used when enabled is set to true. |
 | podAnnotations | object | `{}` | Additional annotations for the deployed pod(s). |
 | resources | object | `{}` | Sets the allocated CPU and memory specifications for the pod(s). |
 | serviceAccountName | string | `""` | If a ServiceAccount is being used, this names it |

--- a/charts/linux-edr-sensor/README.md.gotmpl
+++ b/charts/linux-edr-sensor/README.md.gotmpl
@@ -12,6 +12,8 @@ The {{ template "chart.name" . }} chart has undergone testing for deployment on 
 * Rancher k3s & k3d
 * Amazon EKS
 * Azure AKS
+* Google GKE (see extra configuration requirements below)
+* OpenShift (see special instructions below)
 
 ## Multi-architecture kubernetes clusters
 The current state of the Canary Forwarder Docker image does not support multi-architecture builds. In the context of a multi-architecture Kubernetes cluster (including both arm64 and amd64 nodes), deploying two daemonsets becomes necessary. Each daemonset should reference the respective image and incorporate the required affinities to accommodate this architecture diversity.
@@ -123,6 +125,16 @@ Uninstalling the helm chart will not remove the namespace or image pull secret. 
 
 ```console
 kubectl delete ns <YOUR_NAMESPACE>
+```
+
+## Google Kubernetes Engine Configuration
+
+When installing the sensor in a Google Cloud environment using Google's Container Optimized OS, you must ensure that the persistent directory for node state is placed in a different location than default, because the default location is mounted with the `noexec` flag.
+
+An option to `helm install` that has been tested to work is the following:
+
+```console
+--set persistence.nodestateDir=/var/lib/toolbox/redcanary
 ```
 
 ## OpenShift Install

--- a/charts/linux-edr-sensor/templates/daemonset.yaml
+++ b/charts/linux-edr-sensor/templates/daemonset.yaml
@@ -68,9 +68,13 @@ spec:
           secret:
             secretName: {{ include "linux-edr-sensor.fullname" . }}
         - name: nodestate
+          {{- if .Values.persistence.enabled }}
           hostPath:
-            path: /var/lib/misc/redcanary
+            path: {{ .Values.persistence.nodestateDir }}
             type: DirectoryOrCreate
+          {{- else }}
+          emptyDir:
+          {{ end }}
         - name: tmp
           {{- if .Values.persistence.enabled }}
           hostPath:

--- a/charts/linux-edr-sensor/values.yaml
+++ b/charts/linux-edr-sensor/values.yaml
@@ -68,11 +68,13 @@ useServiceAccount: false
 serviceAccountName: ""
 
 persistence:
-  # -- Whether or not persistent storage should be used for the sensor's /tmp and /logs data.
+  # -- Whether or not persistent storage should be used for the sensor's /var, /tmp and /logs data.
   enabled: true
-  # -- The path on the host to use for persistent tmp storage. Only used when type is set to 'hostpath'.
+  # -- The path on the host to use for persistent node state. You must ensure this is not on a mount with the 'noexec' flag. Only used when enabled is set to true.
+  nodestateDir: /var/lib/misc/redcanary
+  # -- The path on the host to use for persistent tmp storage. Only used when enabled is set to true.
   tmpDir: /tmp
-  # -- The path on the host to use for persistent log storage. Only used when type is set to 'hostpath'.
+  # -- The path on the host to use for persistent log storage. Only used when enabled is set to true.
   logDir: /var/log
 
 # -- Values used for the default configuration. These will not be used if overrideConfig is set to true.


### PR DESCRIPTION
# Description

Fixes # LE-1293

The helm chart did not allow the necessary configuration to fix the mount location of the `nodestate` mount. In GKE clusters running GCOS Linux, the base `/var/lib` directory is flagged `noexec` which prevents plugins from running with our default of `/var/lib/misc/redcanary`. The helm chart did not provide a way to change that away from the default as it does for the `tmp` and `log` directories.

These changes make the `nodestate` mount similarly overridable and update the README docs to describe a viable alternative value for GKE.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I ran these changes against a GKE cluster and verified that the sensor installed with these changes (and the described setting from the README) and was able to run plugins.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
